### PR TITLE
Add possible fix to labels mismatch

### DIFF
--- a/Task_2/mlcubes/data_prep/project/sanity_check.py
+++ b/Task_2/mlcubes/data_prep/project/sanity_check.py
@@ -40,7 +40,7 @@ def check_subject_validity(
             wrong_spacing.append(str(file_))
         if file_.name.endswith("seg.nii.gz"):
             arr = sitk.GetArrayFromImage(image)
-            found_labels = np.unique(arr)
+            found_labels = np.unique(arr).astype(int)
             if len(set(found_labels).difference(EXPECTED_LABELS)) > 0:
                 wrong_labels.append(str(file_))
     return missing_files, wrong_size, wrong_spacing, wrong_labels


### PR DESCRIPTION
Some people have reported having their data preparation step fail due to labels being outside the range {0, 1, 2, 4}. They have already reported they inspected the data and it shouldn't have this mismatch. We believe it might be because of a type difference between the retrieved labels and the expected ones.